### PR TITLE
bugfix: “AttributeError: 'module' object has no attribute 'frontend'”

### DIFF
--- a/ts_charting/ipython.py
+++ b/ts_charting/ipython.py
@@ -7,7 +7,11 @@ from ts_charting import reset_figure
 
 IN_NOTEBOOK = True
 instance = IPython.Application._instance
-if isinstance(instance, IPython.frontend.terminal.ipapp.TerminalIPythonApp):
+if hasattr(IPython, 'frontend'):
+    term = IPython.frontend.terminal.ipapp.TerminalIPythonApp
+else:
+    term = IPython.terminal.ipapp.TerminalIPythonApp
+if isinstance(instance, term):
     IN_NOTEBOOK = False
 
 def figsize(width, height):


### PR DESCRIPTION
in IPython 1.x "terminal" is no longer class of "frontend" but of "IPython" itself
